### PR TITLE
Fixed SQL template unable to import

### DIFF
--- a/lancache_db.sql
+++ b/lancache_db.sql
@@ -61,7 +61,7 @@ INSERT INTO `cache_disk` (`Location`, `KiBUsed`, `KiBFree`) VALUES
 
 CREATE TABLE `steamapps` (
   `AppID` int NOT NULL,
-  `AppName` varchar(500) NOT NULL
+  `AppName` varchar(500) NOT NULL,
   PRIMARY KEY (`AppID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
**Issue:**
Import the SQL file into Mysql (using PhpMyAdmin) with following error:
```
#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(`AppID`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4' at line 10
```
**Solution:**
Added missing comma on line 64.